### PR TITLE
Propagate exit code from Python script

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,22 +1,22 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.32.0
+    rev: v2.37.3
     hooks:
       - id: pyupgrade
         args: [--py37-plus]
         files: ^scripts/
   - repo: https://github.com/asottile/reorder_python_imports
-    rev: v3.1.0
+    rev: v3.8.2
     hooks:
       - id: reorder-python-imports
         files: ^scripts/
   - repo: https://github.com/ambv/black
-    rev: 22.3.0
+    rev: 22.6.0
     hooks:
       - id: black
         files: ^scripts/
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.2
+  - repo: https://github.com/pycqa/flake8
+    rev: 5.0.4
     hooks:
       - id: flake8
         additional_dependencies: [
@@ -27,7 +27,7 @@ repos:
         args: ["--suppress-none-returning"]
         files: ^scripts/
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v4.3.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -40,18 +40,18 @@ repos:
         args: ["--in-place", "--pre-summary-newline"]
         files: ^scripts/
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.942
+    rev: v0.971
     hooks:
       - id: mypy
         additional_dependencies: []
         files: ^scripts/
   - repo: https://github.com/PyCQA/doc8
-    rev: 0.11.1
+    rev: v1.0.0
     hooks:
       - id: doc8
         files: ^scripts/
   - repo: https://github.com/jumanjihouse/pre-commit-hooks
-    rev: 2.1.6
+    rev: 3.0.0
     hooks:
       - id: markdownlint
   - repo: local

--- a/scripts/fetch_vault_credentials.sh
+++ b/scripts/fetch_vault_credentials.sh
@@ -2,10 +2,11 @@
 
 SCRIPTPATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-SCRIPT_OUTPUT=$($SCRIPTPATH/fetch_vault_credentials.py)
+PYTHON_SCRIPT_OUTPUT=$($SCRIPTPATH/fetch_vault_credentials.py)
+PYTHON_SCRIPT_EXIT_CODE=$?
 
-if [ $? == 0 ]; then
-    eval "${SCRIPT_OUTPUT}"
+if [ ${PYTHON_SCRIPT_EXIT_CODE} == 0 ]; then
+    eval "${PYTHON_SCRIPT_OUTPUT}"
 else
-    exit $?
+    exit ${PYTHON_SCRIPT_EXIT_CODE}
 fi

--- a/scripts/fetch_vault_credentials.sh
+++ b/scripts/fetch_vault_credentials.sh
@@ -1,4 +1,11 @@
 #!/usr/bin/env bash
 
 SCRIPTPATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-eval "$($SCRIPTPATH/fetch_vault_credentials.py)"
+
+SCRIPT_OUTPUT=$($SCRIPTPATH/fetch_vault_credentials.py)
+
+if [ $? == 0 ]; then
+    eval "${SCRIPT_OUTPUT}"
+else
+    exit $?
+fi

--- a/scripts/fetch_vault_credentials.sh
+++ b/scripts/fetch_vault_credentials.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-SCRIPTPATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 set -euo pipefail
+
+SCRIPTPATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PYTHON_SCRIPT_OUTPUT="$($SCRIPTPATH/fetch_vault_credentials.py)"
 eval "$PYTHON_SCRIPT_OUTPUT"

--- a/scripts/fetch_vault_credentials.sh
+++ b/scripts/fetch_vault_credentials.sh
@@ -1,12 +1,6 @@
 #!/usr/bin/env bash
 
 SCRIPTPATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-
-PYTHON_SCRIPT_OUTPUT=$($SCRIPTPATH/fetch_vault_credentials.py)
-PYTHON_SCRIPT_EXIT_CODE=$?
-
-if [ ${PYTHON_SCRIPT_EXIT_CODE} == 0 ]; then
-    eval "${PYTHON_SCRIPT_OUTPUT}"
-else
-    exit ${PYTHON_SCRIPT_EXIT_CODE}
-fi
+set -euo pipefail
+PYTHON_SCRIPT_OUTPUT="$($SCRIPTPATH/fetch_vault_credentials.py)"
+eval "$PYTHON_SCRIPT_OUTPUT"


### PR DESCRIPTION
I noticed while testing stuff on staging that Heroku dynos were continuing to launch even if something went wrong with the Vault scripts. This could potentially have the undesirable effect of a dyno launching with no secrets defined in its environment, which, depending on the robustness of the codebase, could cause unexpected runtime failures.

Not sure if this is exactly the way to do things but it's a first punt. Also updated repositories used in pre-commit hooks as the old versions were breaking my bits.